### PR TITLE
chmod +x for dylibs on mac

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -67,5 +67,12 @@ class ReadLineConan(ConanFile):
             autotools = self._configure_autotools()
             autotools.install()
 
+        if tools.os_info.is_macos:
+            libdir = os.path.join(self.package_folder, 'lib')
+
+            self.run("chmod +w {p}/libreadline.{v}.dylib".format(p=libdir,
+                                                                 v=self.version))
+            self.run("chmod +w {p}/libhistory.{v}.dylib".format(p=libdir,
+                                                                v=self.version))
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)


### PR DESCRIPTION
The lack of `w` flag is creating problems for me when using it with cmake. I use `fixup_bundle` from [BundleUtilities](https://cmake.org/cmake/help/latest/module/BundleUtilities.html) which needs to be able to modify it. These are the permissions I see without this PR (using stable/7.0):

```
-r-xr-xr-x  1 jenkins  staff   44156 25 jui 04:18 libhistory.7.0.dylib
-r-xr-xr-x  1 jenkins  staff  277736 25 jui 04:18 libreadline.7.0.dylib
```


The end of the regular "install" command on mac gives this, but clearly permissions are ignored.
```
( cd shlib ; /Applications/Xcode.app/Contents/Developer/usr/bin/make - --jobserver-fds=3,7 -j DESTDIR= install )
/bin/sh ../support/mkdirs /Users/jenkins/.conan/data/readline/7.0/jmarrec/testing/package/988863d075519fe477ab5c0452ee71c84a94de8a/lib
/bin/sh ../support/mkdirs /Users/jenkins/.conan/data/readline/7.0/jmarrec/testing/package/988863d075519fe477ab5c0452ee71c84a94de8a/bin
mkdir /Users/jenkins/.conan/data/readline/7.0/jmarrec/testing/package/988863d075519fe477ab5c0452ee71c84a94de8a/bin
/bin/sh ../support/shlib-install -O darwin18.5.0 -V apple -d /Users/jenkins/.conan/data/readline/7.0/jmarrec/testing/package/988863d075519fe477ab5c0452ee71c84a94de8a/lib -b /Users/jenkins/.conan/data/readline/7.0/jmarrec/testing/package/988863d075519fe477ab5c0452ee71c84a94de8a/bin -i "/usr/local/bin/ginstall -c -m 644" libhistory.7.0.dylib
/bin/sh ../support/shlib-install -O darwin18.5.0 -V apple -d /Users/jenkins/.conan/data/readline/7.0/jmarrec/testing/package/988863d075519fe477ab5c0452ee71c84a94de8a/lib -b /Users/jenkins/.conan/data/readline/7.0/jmarrec/testing/package/988863d075519fe477ab5c0452ee71c84a94de8a/bin -i "/usr/local/bin/ginstall -c -m 644" libreadline.7.0.dylib
install: you may need to run ldconfig
```

