### PR TITLE
Allow building static libraries on MacOS

### DIFF
--- a/build.py
+++ b/build.py
@@ -6,6 +6,7 @@ from bincrafters import build_template_default
 
 if __name__ == "__main__":
 
-    shared_option_name = False if platform.system() == "Darwin" else "readline:shared"
-    builder = build_template_default.get_builder(pure_c=True, shared_option_name=shared_option_name)
+    shared_option_name = "readline:shared"
+    builder = build_template_default.get_builder(pure_c=True,
+                                                 shared_option_name=shared_option_name)
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,8 +28,8 @@ class ReadLineConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if self.settings.os == "Macos":
-            del self.options.shared
+        # if self.settings.os == "Macos":
+        #     del self.options.shared
 
     def configure(self):
         del self.settings.compiler.libcxx
@@ -47,7 +47,7 @@ class ReadLineConan(ConanFile):
         if not self._autotools:
             tools.replace_in_file("Makefile.in", "@TERMCAP_LIB@", "-ltermcap")
             configure_args = ['--enable-static', '--disable-shared']
-            if self.settings.os == "Macos" or self.options.shared:
+            if self.options.shared:
                 configure_args = ['--enable-shared', '--disable-static']
             if tools.cross_building(self.settings):
                 configure_args.append('bash_cv_wcwidth_broken=yes')

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,8 +28,6 @@ class ReadLineConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        # if self.settings.os == "Macos":
-        #     del self.options.shared
 
     def configure(self):
         del self.settings.compiler.libcxx


### PR DESCRIPTION
This was disabled without an actual comment explaining why in 05b49a5db8e1701cc638c4f43128aec69ad4fc30 and 27fdb3d8dd79f0c2e90a48baaa4ed439c27aa292.

I can build this locally on a mac right now with the changes I made though. I will try to link against them next while CI tests this too.

